### PR TITLE
Add `mtools` to build dependencies

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,6 +45,7 @@ Once you have Rust installed, you will need the following additional dependencie
 + `ld`
 + `grub-mkrescue` & `xorriso`
 + `qemu` for running the kernel under emulation
++ `mtools`
 
 Depending on your OS, you'll want to install these dependencies somewhat differently.
 
@@ -53,11 +54,11 @@ Depending on your OS, you'll want to install these dependencies somewhat differe
 On Debian you can install them with
 
 ```
-$ sudo apt-get install nasm xorriso qemu build-essential
+$ sudo apt-get install nasm xorriso qemu mtools build-essential
 ```
 On Arch Linux you can install them with
 ```
-$ sudo pacman -S --needed binutils grub libisoburn nasm qemu
+$ sudo pacman -S --needed binutils grub libisoburn nasm qemu mtools
 ```
 And on Fedora with
 ```

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ run-%: $(wild_iso)
 $(wild_iso): $(wild_kernel).bin $(wild_isofiles) $(grub_cfg)
 	@cp $< $(word 2,$^)/boot/
 	@cp $(grub_cfg) $(word 2,$^)/boot/grub
-	@grub-mkrescue -o $@ $(word 2,$^)/
+	grub-mkrescue -o $@ $(word 2,$^)/
 	@rm -r $(word 2,$^)
 
 $(wild_isofiles):

--- a/scripts/install-env-linux.sh
+++ b/scripts/install-env-linux.sh
@@ -39,7 +39,7 @@ case $distro in
             exit
         fi
 
-        sudo apt-get install nasm xorriso qemu build-essential | sed "s/^/${bold}apt-get:${normal} /"
+        sudo apt-get install nasm xorriso qemu build-essential mtools | sed "s/^/${bold}apt-get:${normal} /"
         ;;
     Arch | ManjaroLinux)
         echo "${bold}install-env-linux:${normal} Installing with pacman."
@@ -56,7 +56,7 @@ case $distro in
             exit
         fi
 
-        sudo pacman -S --needed binutils grub libisoburn nasm qemu | sed "s/^/${bold}pacman:${normal} /"
+        sudo pacman -S --needed binutils grub libisoburn nasm qemu mtools | sed "s/^/${bold}pacman:${normal} /"
         ;;
 esac
     # todo: support non-x86_64 architectures here (later)


### PR DESCRIPTION
This PR adds `mtools` to the list of build dependencies on Linux and adds it to the packages installed on Arch/Manjaro and Debian/Ubuntu. Closes #52.

Thanks @rachlmac for fixing this issue.