### PR TITLE
Fix build in specific Linux environment

### DIFF
--- a/x86_64-sos-kernel-gnu.json
+++ b/x86_64-sos-kernel-gnu.json
@@ -8,6 +8,7 @@
     "relocation-model": "static",
     "os": "sos",
     "arch": "x86_64",
+    "linker": "gcc",
     "linker-flavor": "gcc",
     "pre-link-args": {
         "gcc": [ "-Tsrc/arch/x86_64/linker.ld"


### PR DESCRIPTION
Before these changes the Makefile makes the assumption of architecture targeted binaries for `objcopy` and `strip`. These are not available in my environment which is based on a [custom nix-shell derivation](https://github.com/htwg-syslab/nix-expressions/blob/b5eb0cf/shells/default.nix#L423-L439).

I'm curious if this breaks in other environments :-)